### PR TITLE
Fix composite matching using close_to

### DIFF
--- a/precisely/comparison_matchers.py
+++ b/precisely/comparison_matchers.py
@@ -1,5 +1,6 @@
 import operator
 
+from .base import Matcher
 from .results import matched, unmatched
 
 
@@ -51,7 +52,7 @@ def close_to(value, delta):
     return IsCloseToMatcher(value, delta)
 
 
-class IsCloseToMatcher(object):
+class IsCloseToMatcher(Matcher):
     def __init__(self, value, delta):
         self._value = value
         self._delta = delta

--- a/tests/close_to_tests.py
+++ b/tests/close_to_tests.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from nose.tools import istest, assert_equal
 
-from precisely import close_to
+from precisely import close_to, is_sequence
 from precisely.results import matched, unmatched
 
 
@@ -33,3 +33,9 @@ def close_to_matches_datetime_values():
 def close_to_description_describes_value():
     matcher = close_to(42, 1)
     assert_equal("close to 42 +/- 1", matcher.describe())
+
+
+@istest
+def close_to_can_be_used_in_composite_matcher():
+    matcher = is_sequence("a", "b", close_to(42, 1))
+    assert_equal(matched(), matcher.match(("a", "b", 42)))


### PR DESCRIPTION
Make `IsCloseToMatcher` inherit from `Matcher` so it can be used in other matchers. 

NB `ComparisonMatcher` doesn't inherit from `Matcher` either. I can submit another PR once anything here has been corrected. 