### PR TITLE
Add contains_regex(regex_pattern) matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.egg-info
 /.tox
 /MANIFEST
+.idea

--- a/README.rst
+++ b/README.rst
@@ -273,3 +273,15 @@ messages that this project produces, but feel free to judge for yourself:
     # Hamcrest error:
     # Expected: a sequence containing [(an object with a property 'username' matching 'bob' and an object with a property 'email_address' matching 'bob@example.com'), (an object with a property 'username' matching 'jim' and an object with a property 'email_address' matching 'jim@example.com')]
     #      but: item 0: an object with a property 'email_address' matching 'bob@example.com' property 'email_address' was 'jim@example.com'
+
+
+Contributing
+------------
+
+  .. code:: bash
+
+  # setup
+  make bootstrap
+
+  # run tests
+  make test

--- a/README.rst
+++ b/README.rst
@@ -184,6 +184,13 @@ For instance, ``has_attrs(name="bob")`` is equivalent to ``has_attrs(name=equal_
 
 * ``contains_string(substring)``: matches a string if it contains ``substring``.
 
+* ``contains_regex(regex_pattern)``: matches a string if string matches regex ``regex_pattern``.
+  For instance:
+
+  .. code:: python
+
+      assert_that("Hello there", contains_regex("^Hello.*"))
+
 * ``greater_than(value)``: matches values greater than ``value``.
 
 * ``greater_than_or_equal_to(value)``: matches values greater than or equal to ``value``.

--- a/precisely/__init__.py
+++ b/precisely/__init__.py
@@ -1,5 +1,6 @@
 from .base import Matcher, is_matcher
-from .comparison_matchers import contains_string, greater_than, greater_than_or_equal_to, less_than, less_than_or_equal_to, starts_with, close_to
+from .comparison_matchers import contains_string, contains_regex, greater_than, greater_than_or_equal_to, less_than, \
+    less_than_or_equal_to, starts_with, close_to
 from .core_matchers import equal_to, anything, all_of, any_of, not_
 from .object_matchers import has_attr, has_attrs, is_instance
 from .iterable_matchers import all_elements, contains_exactly, includes, is_sequence
@@ -14,6 +15,7 @@ __all__ = [
     "Matcher",
     "is_matcher",
     "contains_string",
+    "contains_regex",
     "greater_than",
     "greater_than_or_equal_to",
     "less_than",

--- a/precisely/comparison_matchers.py
+++ b/precisely/comparison_matchers.py
@@ -1,4 +1,5 @@
 import operator
+import re
 
 from .base import Matcher
 from .results import matched, unmatched
@@ -6,6 +7,13 @@ from .results import matched, unmatched
 
 def contains_string(value):
     return ComparisonMatcher(operator.contains, "contains the string", value)
+
+
+def contains_regex(value):
+    def regex_match_operator(string, pattern):
+        return re.match(pattern, string)
+
+    return ComparisonMatcher(regex_match_operator, "contains the regex pattern", value)
 
 
 def greater_than(value):

--- a/tests/contains_regex_tests.py
+++ b/tests/contains_regex_tests.py
@@ -1,0 +1,21 @@
+from nose.tools import istest, assert_equal
+
+from precisely import contains_regex
+from precisely.results import matched, unmatched
+
+
+@istest
+def contains_regex_matches_when_actual_string_matches_regex_pattern_passed_to_matcher():
+    matcher = contains_regex(".*[Hh]ello$")
+
+    assert_equal(matched(), matcher.match("hello"))
+    assert_equal(matched(), matcher.match("Hello"))
+    assert_equal(matched(), matcher.match("why hello"))
+    assert_equal(unmatched("was 'why hello there'"), matcher.match("why hello there"))
+
+
+@istest
+def contains_regex_description_describes_value():
+    matcher = contains_regex(".*")
+
+    assert_equal("contains the regex pattern '.*'", matcher.describe())


### PR DESCRIPTION
Heya @mwilliamson , thanks again for the great work on this library.

This PR adds a new matcher `contains_regex(...)`, as requested in https://github.com/mwilliamson/python-precisely/issues/16. For example:

```
assert_that("2020-01-01", contains_regex(r'[\d]{4}-[\d]{2}-[\d]{2}'))
```

I've added unit tests for the new method, and all the unit tests are passing

Keen to hear your thoughts/feedback. Cheers :-)