### PR TITLE
Replace nose with pytest

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 .PHONY: test upload clean bootstrap
 
 test:
-	sh -c '. _virtualenv/bin/activate; nosetests tests'
+	sh -c '. _virtualenv/bin/activate; pytest tests/*_tests.py'
 	_virtualenv/bin/pyflakes precisely tests
 
 test-all:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-nose>1,<2
+pytest>=6.0.0
 PyHamcrest==1.9.0
 pyflakes==2.2.0

--- a/tests/all_elements_tests.py
+++ b/tests/all_elements_tests.py
@@ -1,48 +1,33 @@
-from nose.tools import istest, assert_equal
 
 from precisely import all_elements, equal_to
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_all_items_in_iterable_match():
+def test_matches_when_all_items_in_iterable_match():
     matcher = all_elements(equal_to("apple"))
 
-    assert_equal(matched(), matcher.match(["apple", "apple"]))
+    assert matched() == matcher.match(["apple", "apple"])
 
 
-@istest
-def mismatches_when_actual_is_not_iterable():
+def test_mismatches_when_actual_is_not_iterable():
     matcher = all_elements(equal_to("apple"))
     
-    assert_equal(
-        unmatched("was not iterable\nwas 0"),
-        matcher.match(0)
-    )
+    assert unmatched("was not iterable\nwas 0") == matcher.match(0)
 
 
-@istest
-def mismatches_when_item_in_iterable_does_not_match():
+def test_mismatches_when_item_in_iterable_does_not_match():
     matcher = all_elements(equal_to("apple"))
 
-    assert_equal(
-        unmatched("element at index 1 mismatched: was 'orange'"),
-        matcher.match(["apple", "orange"])
-    )
+    assert unmatched("element at index 1 mismatched: was 'orange'") == matcher.match(["apple", "orange"])
 
 
-@istest
-def matches_when_iterable_is_empty():
+def test_matches_when_iterable_is_empty():
     matcher = all_elements(equal_to("apple"))
 
-    assert_equal(matched(), matcher.match([]))
+    assert matched() == matcher.match([])
 
 
-@istest
-def description_contains_descriptions_of_submatcher():
+def test_description_contains_descriptions_of_submatcher():
     matcher = all_elements(equal_to("apple"))
 
-    assert_equal(
-        "all elements of iterable match: 'apple'",
-        matcher.describe()
-    )
+    assert "all elements of iterable match: 'apple'" == matcher.describe()

--- a/tests/all_of_tests.py
+++ b/tests/all_of_tests.py
@@ -1,6 +1,5 @@
 import collections
 
-from nose.tools import istest, assert_equal
 
 from precisely import all_of, has_attr, equal_to
 from precisely.results import matched, unmatched
@@ -8,38 +7,29 @@ from precisely.results import matched, unmatched
 
 User = collections.namedtuple("User", ["username", "email_address"])
 
-@istest
-def matches_when_submatchers_all_match():
+def test_matches_when_submatchers_all_match():
     matcher = all_of(
         has_attr("username", equal_to("bob")),
         has_attr("email_address", equal_to("bob@example.com")),
     )
-    
-    assert_equal(matched(), matcher.match(User("bob", "bob@example.com")))
+
+    assert matched() == matcher.match(User("bob", "bob@example.com"))
 
 
-@istest
-def mismatches_when_submatcher_mismatches():
+def test_mismatches_when_submatcher_mismatches():
     matcher = all_of(
         has_attr("username", equal_to("bob")),
         has_attr("email_address", equal_to("bob@example.com")),
     )
-    
-    assert_equal(
-        unmatched("was missing attribute username"),
-        matcher.match("bobbity")
-    )
+
+    assert unmatched("was missing attribute username") == matcher.match("bobbity")
 
 
-@istest
-def description_contains_descriptions_of_submatchers():
+def test_description_contains_descriptions_of_submatchers():
     matcher = all_of(
         has_attr("username", equal_to("bob")),
         has_attr("email_address", equal_to("bob@example.com")),
     )
-    
-    assert_equal(
-        "all of:\n * object with attribute username: 'bob'\n * object with attribute email_address: 'bob@example.com'",
-        matcher.describe()
-    )
+
+    assert "all of:\n * object with attribute username: 'bob'\n * object with attribute email_address: 'bob@example.com'" == matcher.describe()
 

--- a/tests/any_of_tests.py
+++ b/tests/any_of_tests.py
@@ -1,6 +1,5 @@
 import collections
 
-from nose.tools import istest, assert_equal
 
 from precisely import any_of, has_attr, equal_to
 from precisely.results import matched, unmatched
@@ -8,51 +7,38 @@ from precisely.results import matched, unmatched
 
 User = collections.namedtuple("User", ["username", "email_address"])
 
-@istest
-def matches_when_submatchers_all_match():
+def test_matches_when_submatchers_all_match():
     matcher = any_of(
         has_attr("username", equal_to("bob")),
         has_attr("email_address", equal_to("bob@example.com")),
     )
-    
-    assert_equal(matched(), matcher.match(User("bob", "bob@example.com")))
+
+    assert matched() == matcher.match(User("bob", "bob@example.com"))
 
 
-@istest
-def matches_when_any_submatchers_match():
+def test_matches_when_any_submatchers_match():
     matcher = any_of(
         equal_to("bob"),
         equal_to("jim"),
     )
-    
-    assert_equal(
-        matched(),
-        matcher.match("bob"),
-    )
+
+    assert matched() == matcher.match("bob")
 
 
-@istest
-def mismatches_when_no_submatchers_match():
+def test_mismatches_when_no_submatchers_match():
     matcher = any_of(
         equal_to("bob"),
         equal_to("jim"),
     )
-    
-    assert_equal(
-        unmatched("did not match any of:\n * 'bob' [was 'alice']\n * 'jim' [was 'alice']"),
-        matcher.match("alice"),
-    )
+
+    assert unmatched("did not match any of:\n * 'bob' [was 'alice']\n * 'jim' [was 'alice']") == matcher.match("alice")
 
 
-@istest
-def description_contains_descriptions_of_submatchers():
+def test_description_contains_descriptions_of_submatchers():
     matcher = any_of(
         has_attr("username", equal_to("bob")),
         has_attr("email_address", equal_to("bob@example.com")),
     )
-    
-    assert_equal(
-        "any of:\n * object with attribute username: 'bob'\n * object with attribute email_address: 'bob@example.com'",
-        matcher.describe()
-    )
+
+    assert "any of:\n * object with attribute username: 'bob'\n * object with attribute email_address: 'bob@example.com'" == matcher.describe()
 

--- a/tests/anything_tests.py
+++ b/tests/anything_tests.py
@@ -1,17 +1,14 @@
-from nose.tools import istest, assert_equal
 
 from precisely import anything
 from precisely.results import matched
 
 
-@istest
-def matches_anything():
-    assert_equal(matched(), anything.match(4))
-    assert_equal(matched(), anything.match(None))
-    assert_equal(matched(), anything.match("Hello"))
+def test_matches_anything():
+    assert matched() == anything.match(4)
+    assert matched() == anything.match(None)
+    assert matched() == anything.match("Hello")
 
 
-@istest
-def description_is_anything():
-    assert_equal("anything", anything.describe())
+def test_description_is_anything():
+    assert "anything" == anything.describe()
 

--- a/tests/assert_that_tests.py
+++ b/tests/assert_that_tests.py
@@ -1,17 +1,14 @@
-from nose.tools import istest, assert_equal
 
 from precisely import assert_that, equal_to
 
 
-@istest
-def assert_that_does_nothing_if_matcher_matches():
+def test_assert_that_does_nothing_if_matcher_matches():
     assert_that(1, equal_to(1))
 
 
-@istest
-def assert_that_raises_assertion_error_if_match_fails():
+def test_assert_that_raises_assertion_error_if_match_fails():
     try:
         assert_that(1, equal_to(2))
         assert False, "Expected AssertionError"
     except AssertionError as error:
-        assert_equal("\nExpected:\n  2\nbut:\n  was 1", str(error))
+        assert "\nExpected:\n  2\nbut:\n  was 1" == str(error)

--- a/tests/close_to_tests.py
+++ b/tests/close_to_tests.py
@@ -1,24 +1,21 @@
 import functools
 
-from nose.tools import istest, assert_equal
 
 from precisely import close_to, is_sequence
 from precisely.results import matched, unmatched
 
 
-@istest
-def close_to_matches_when_actual_is_close_to_value_plus_delta():
+def test_close_to_matches_when_actual_is_close_to_value_plus_delta():
     matcher = close_to(42, 1)
-    assert_equal(matched(), matcher.match(43))
-    assert_equal(matched(), matcher.match(42.5))
-    assert_equal(matched(), matcher.match(42))
-    assert_equal(matched(), matcher.match(41.5))
-    assert_equal(matched(), matcher.match(41))
-    assert_equal(unmatched("was 40 (2 away from 42)"), matcher.match(40))
+    assert matched() == matcher.match(43)
+    assert matched() == matcher.match(42.5)
+    assert matched() == matcher.match(42)
+    assert matched() == matcher.match(41.5)
+    assert matched() == matcher.match(41)
+    assert unmatched("was 40 (2 away from 42)") == matcher.match(40)
 
 
-@istest
-def close_to_matches_any_types_supporting_comparison_and_addition_and_subtraction():
+def test_close_to_matches_any_types_supporting_comparison_and_addition_and_subtraction():
     class Instant(object):
         def __init__(self, seconds_since_epoch):
             self.seconds_since_epoch = seconds_since_epoch
@@ -56,21 +53,19 @@ def close_to_matches_any_types_supporting_comparison_and_addition_and_subtractio
             return "Interval({})".format(self.seconds)
 
     matcher = close_to(Instant(42), Interval(1))
-    assert_equal(matched(), matcher.match(Instant(43)))
-    assert_equal(matched(), matcher.match(Instant(42.5)))
-    assert_equal(matched(), matcher.match(Instant(42)))
-    assert_equal(matched(), matcher.match(Instant(41.5)))
-    assert_equal(matched(), matcher.match(Instant(41)))
-    assert_equal(unmatched("was Instant(40) (Interval(2) away from Instant(42))"), matcher.match(Instant(40)))
+    assert matched() == matcher.match(Instant(43))
+    assert matched() == matcher.match(Instant(42.5))
+    assert matched() == matcher.match(Instant(42))
+    assert matched() == matcher.match(Instant(41.5))
+    assert matched() == matcher.match(Instant(41))
+    assert unmatched("was Instant(40) (Interval(2) away from Instant(42))") == matcher.match(Instant(40))
 
 
-@istest
-def close_to_description_describes_value():
+def test_close_to_description_describes_value():
     matcher = close_to(42, 1)
-    assert_equal("close to 42 +/- 1", matcher.describe())
+    assert "close to 42 +/- 1" == matcher.describe()
 
 
-@istest
-def close_to_can_be_used_in_composite_matcher():
+def test_close_to_can_be_used_in_composite_matcher():
     matcher = is_sequence("a", "b", close_to(42, 1))
-    assert_equal(matched(), matcher.match(("a", "b", 42)))
+    assert matched() == matcher.match(("a", "b", 42))

--- a/tests/contains_exactly_tests.py
+++ b/tests/contains_exactly_tests.py
@@ -1,109 +1,70 @@
-from nose.tools import istest, assert_equal
 
 from precisely import contains_exactly, equal_to
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_all_submatchers_match_one_item_with_no_items_leftover():
+def test_matches_when_all_submatchers_match_one_item_with_no_items_leftover():
     matcher = contains_exactly(equal_to("apple"), equal_to("banana"))
 
-    assert_equal(matched(), matcher.match(["banana", "apple"]))
+    assert matched() == matcher.match(["banana", "apple"])
 
 
-@istest
-def mismatches_when_actual_is_not_iterable():
+def test_mismatches_when_actual_is_not_iterable():
     matcher = contains_exactly()
 
-    assert_equal(
-        unmatched("was not iterable\nwas 0"),
-        matcher.match(0)
-    )
+    assert unmatched("was not iterable\nwas 0") == matcher.match(0)
 
 
-@istest
-def mismatches_when_item_is_missing():
+def test_mismatches_when_item_is_missing():
     matcher = contains_exactly(equal_to("apple"), equal_to("banana"), equal_to("coconut"))
 
-    assert_equal(
-        unmatched("was missing element:\n * 'banana'\nThese elements were in the iterable, but did not match the missing element:\n * 'coconut': was 'coconut'\n * 'apple': already matched"),
-        matcher.match(["coconut", "apple"])
-    )
+    assert unmatched("was missing element:\n * 'banana'\nThese elements were in the iterable, but did not match the missing element:\n * 'coconut': was 'coconut'\n * 'apple': already matched") == matcher.match(["coconut", "apple"])
 
 
-@istest
-def mismatches_when_duplicate_is_missing():
+def test_mismatches_when_duplicate_is_missing():
     matcher = contains_exactly(equal_to("apple"), equal_to("apple"))
 
-    assert_equal(
-        unmatched("was missing element:\n * 'apple'\nThese elements were in the iterable, but did not match the missing element:\n * 'apple': already matched"),
-        matcher.match(["apple"])
-    )
+    assert unmatched("was missing element:\n * 'apple'\nThese elements were in the iterable, but did not match the missing element:\n * 'apple': already matched") == matcher.match(["apple"])
 
 
-@istest
-def mismatches_when_item_is_expected_but_iterable_is_empty():
+def test_mismatches_when_item_is_expected_but_iterable_is_empty():
     matcher = contains_exactly(equal_to("apple"))
 
-    assert_equal(
-        unmatched("iterable was empty"),
-        matcher.match([])
-    )
+    assert unmatched("iterable was empty") == matcher.match([])
 
 
-@istest
-def when_empty_iterable_is_expected_then_empty_iterable_matches():
+def test_when_empty_iterable_is_expected_then_empty_iterable_matches():
     matcher = contains_exactly()
 
-    assert_equal(
-        matched(),
-        matcher.match([])
-    )
+    assert matched() == matcher.match([])
 
 
-@istest
-def mismatches_when_contains_extra_item():
+def test_mismatches_when_contains_extra_item():
     matcher = contains_exactly(equal_to("apple"))
 
-    assert_equal(
-        unmatched("had extra elements:\n * 'coconut'"),
-        matcher.match(["coconut", "apple"])
-    )
+    assert unmatched("had extra elements:\n * 'coconut'") == matcher.match(["coconut", "apple"])
 
 
-@istest
-def description_is_of_empty_iterable_when_there_are_zero_submatchers():
+def test_description_is_of_empty_iterable_when_there_are_zero_submatchers():
     matcher = contains_exactly()
 
-    assert_equal("empty iterable", matcher.describe())
+    assert "empty iterable" == matcher.describe()
 
 
-@istest
-def description_uses_singular_when_there_is_one_submatcher():
+def test_description_uses_singular_when_there_is_one_submatcher():
     matcher = contains_exactly(equal_to("apple"))
 
-    assert_equal(
-        "iterable containing 1 element:\n * 'apple'",
-        matcher.describe()
-    )
+    assert "iterable containing 1 element:\n * 'apple'" == matcher.describe()
 
 
-@istest
-def description_contains_descriptions_of_submatchers():
+def test_description_contains_descriptions_of_submatchers():
     matcher = contains_exactly(equal_to("apple"), equal_to("banana"))
 
-    assert_equal(
-        "iterable containing these 2 elements in any order:\n * 'apple'\n * 'banana'",
-        matcher.describe()
-    )
+    assert "iterable containing these 2 elements in any order:\n * 'apple'\n * 'banana'" == matcher.describe()
 
 
-@istest
-def elements_are_coerced_to_matchers():
+def test_elements_are_coerced_to_matchers():
     matcher = contains_exactly("apple", "banana")
 
-    assert_equal(
-        "iterable containing these 2 elements in any order:\n * 'apple'\n * 'banana'",
-        matcher.describe()
-    )
+    assert "iterable containing these 2 elements in any order:\n * 'apple'\n * 'banana'" == matcher.describe()
 

--- a/tests/contains_string_tests.py
+++ b/tests/contains_string_tests.py
@@ -1,21 +1,17 @@
-from nose.tools import istest, assert_equal
-
 from precisely import contains_string
 from precisely.results import matched, unmatched
 
 
-@istest
-def contains_string_matches_when_actual_string_contains_value_passed_to_matcher():
+def test_contains_string_matches_when_actual_string_contains_value_passed_to_matcher():
     matcher = contains_string("ab")
-    assert_equal(matched(), matcher.match("ab"))
-    assert_equal(matched(), matcher.match("abc"))
-    assert_equal(matched(), matcher.match("abcd"))
-    assert_equal(matched(), matcher.match("cabd"))
-    assert_equal(matched(), matcher.match("cdab"))
-    assert_equal(unmatched("was 'a'"), matcher.match("a"))
+    assert matched() == matcher.match("ab")
+    assert matched() == matcher.match("abc")
+    assert matched() == matcher.match("abcd")
+    assert matched() == matcher.match("cabd")
+    assert matched() == matcher.match("cdab")
+    assert unmatched("was 'a'") == matcher.match("a")
 
 
-@istest
-def contains_string_description_describes_value():
+def test_contains_string_description_describes_value():
     matcher = contains_string("ab")
-    assert_equal("contains the string 'ab'", matcher.describe())
+    assert matcher.describe() == "contains the string 'ab'"

--- a/tests/equal_to_tests.py
+++ b/tests/equal_to_tests.py
@@ -1,20 +1,16 @@
-from nose.tools import istest, assert_equal
 
 from precisely import equal_to
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_values_are_equal():
-    assert_equal(matched(), equal_to(1).match(1))
+def test_matches_when_values_are_equal():
+    assert matched() == equal_to(1).match(1)
 
 
-@istest
-def explanation_of_mismatch_contains_repr_of_actual():
-    assert_equal(unmatched("was 2"), equal_to(1).match(2))
-    assert_equal(unmatched("was 'hello'"), equal_to(1).match("hello"))
+def test_explanation_of_mismatch_contains_repr_of_actual():
+    assert unmatched("was 2") == equal_to(1).match(2)
+    assert unmatched("was 'hello'") == equal_to(1).match("hello")
 
 
-@istest
-def description_is_repr_of_value():
-    assert_equal("'hello'", equal_to("hello").describe())
+def test_description_is_repr_of_value():
+    assert equal_to("hello").describe() == "'hello'"

--- a/tests/has_attr_tests.py
+++ b/tests/has_attr_tests.py
@@ -1,6 +1,5 @@
 import collections
 
-from nose.tools import istest, assert_equal
 
 from precisely import has_attr, equal_to
 from precisely.results import matched, unmatched
@@ -9,39 +8,22 @@ from precisely.results import matched, unmatched
 User = collections.namedtuple("User", ["username"])
 
 
-@istest
-def matches_when_property_has_correct_value():
-    assert_equal(matched(), has_attr("username", equal_to("bob")).match(User("bob")))
+def test_matches_when_property_has_correct_value():
+    assert matched() == has_attr("username", equal_to("bob")).match(User("bob"))
 
 
-@istest
-def mismatches_when_property_is_missing():
-    assert_equal(
-        unmatched("was missing attribute username"),
-        has_attr("username", equal_to("bob")).match("bobbity")
-    )
+def test_mismatches_when_property_is_missing():
+    assert unmatched("was missing attribute username") == has_attr("username", equal_to("bob")).match("bobbity")
 
 
-@istest
-def explanation_of_mismatch_contains_mismatch_of_property():
-    assert_equal(
-        unmatched("attribute username was 'bobbity'"),
-        has_attr("username", equal_to("bob")).match(User("bobbity"))
-    )
+def test_explanation_of_mismatch_contains_mismatch_of_property():
+    assert unmatched("attribute username was 'bobbity'") == has_attr("username", equal_to("bob")).match(User("bobbity"))
 
 
-@istest
-def submatcher_is_coerced_to_matcher():
-    assert_equal(
-        unmatched("attribute username was 'bobbity'"),
-        has_attr("username", "bob").match(User("bobbity"))
-    )
+def test_submatcher_is_coerced_to_matcher():
+    assert unmatched("attribute username was 'bobbity'") == has_attr("username", "bob").match(User("bobbity"))
 
 
-@istest
-def description_contains_description_of_property():
-    assert_equal(
-        "object with attribute username: 'bob'",
-        has_attr("username", equal_to("bob")).describe()
-    )
+def test_description_contains_description_of_property():
+    assert "object with attribute username: 'bob'" == has_attr("username", equal_to("bob")).describe()
 

--- a/tests/has_attrs_tests.py
+++ b/tests/has_attrs_tests.py
@@ -1,6 +1,5 @@
 import collections
 
-from nose.tools import istest, assert_equal
 
 from precisely import has_attrs, equal_to
 from precisely.results import matched, unmatched
@@ -8,84 +7,59 @@ from precisely.results import matched, unmatched
 
 User = collections.namedtuple("User", ["username", "email_address"])
 
-@istest
-def matches_when_properties_all_match():
+def test_matches_when_properties_all_match():
     matcher = has_attrs(
         username=equal_to("bob"),
         email_address=equal_to("bob@example.com"),
     )
     
-    assert_equal(matched(), matcher.match(User("bob", "bob@example.com")))
+    assert matched() == matcher.match(User("bob", "bob@example.com"))
 
 
-@istest
-def mismatches_when_property_is_missing():
+def test_mismatches_when_property_is_missing():
     matcher = has_attrs(
         ("username", equal_to("bob")),
         ("email_address", equal_to("bob@example.com")),
     )
     
-    assert_equal(
-        unmatched("was missing attribute username"),
-        matcher.match("bobbity")
-    )
+    assert unmatched("was missing attribute username") == matcher.match("bobbity")
 
 
-@istest
-def explanation_of_mismatch_contains_mismatch_of_property():
+def test_explanation_of_mismatch_contains_mismatch_of_property():
     matcher = has_attrs(
         username=equal_to("bob"),
         email_address=equal_to("bob@example.com"),
     )
     
-    assert_equal(
-        unmatched("attribute email_address was 'bobbity@example.com'"),
-        matcher.match(User("bob", "bobbity@example.com"))
-    )
+    assert unmatched("attribute email_address was 'bobbity@example.com'") == matcher.match(User("bob", "bobbity@example.com"))
 
 
-@istest
-def submatcher_is_coerced_to_matcher():
+def test_submatcher_is_coerced_to_matcher():
     matcher = has_attrs(username="bob")
     
-    assert_equal(
-        unmatched("attribute username was 'bobbity'"),
-        matcher.match(User("bobbity", None))
-    )
+    assert unmatched("attribute username was 'bobbity'") == matcher.match(User("bobbity", None))
 
 
-@istest
-def description_contains_descriptions_of_properties():
+def test_description_contains_descriptions_of_properties():
     matcher = has_attrs(
         username=equal_to("bob"),
     )
-    
-    assert_equal(
-        "object with attributes:\n * username: 'bob'",
-        matcher.describe()
-    )
+
+    assert "object with attributes:\n * username: 'bob'" == matcher.describe()
 
 
-@istest
-def can_pass_properties_as_list_of_tuples():
+def test_can_pass_properties_as_list_of_tuples():
     matcher = has_attrs(
         ("username", equal_to("bob")),
         ("email_address", equal_to("bob@example.com")),
     )
-    
-    assert_equal(
-        "object with attributes:\n * username: 'bob'\n * email_address: 'bob@example.com'",
-        matcher.describe()
-    )
+
+    assert "object with attributes:\n * username: 'bob'\n * email_address: 'bob@example.com'" == matcher.describe()
 
 
-@istest
-def can_pass_properties_as_dictionary():
+def test_can_pass_properties_as_dictionary():
     matcher = has_attrs({
         "username": equal_to("bob"),
     })
-    
-    assert_equal(
-        "object with attributes:\n * username: 'bob'",
-        matcher.describe()
-    )
+
+    assert "object with attributes:\n * username: 'bob'" == matcher.describe()

--- a/tests/has_feature_tests.py
+++ b/tests/has_feature_tests.py
@@ -1,6 +1,5 @@
 import collections
 
-from nose.tools import istest, assert_equal
 
 from precisely import has_feature, equal_to
 from precisely.results import matched, unmatched
@@ -9,46 +8,29 @@ from precisely.results import matched, unmatched
 User = collections.namedtuple("User", ["username"])
 
 
-@istest
-def matches_when_feature_has_correct_value():
+def test_matches_when_feature_has_correct_value():
     matcher = has_feature("name", lambda user: user.username, equal_to("bob"))
-    assert_equal(matched(), matcher.match(User("bob")))
+    assert matched() == matcher.match(User("bob"))
 
 
-@istest
-def mismatches_when_feature_extraction_fails():
+def test_mismatches_when_feature_extraction_fails():
     # TODO:
     return
     matcher = has_feature("name", lambda user: user.username, equal_to("bob"))
-    assert_equal(
-        unmatched(""),
-        matcher.match("bobbity")
-    )
+    assert unmatched("") == matcher.match("bobbity")
 
 
-@istest
-def explanation_of_mismatch_contains_mismatch_of_feature():
+def test_explanation_of_mismatch_contains_mismatch_of_feature():
     matcher = has_feature("name", lambda user: user.username, equal_to("bob"))
-    assert_equal(
-        unmatched("name: was 'bobbity'"),
-        matcher.match(User("bobbity"))
-    )
+    assert unmatched("name: was 'bobbity'") == matcher.match(User("bobbity"))
 
 
-@istest
-def submatcher_is_coerced_to_matcher():
+def test_submatcher_is_coerced_to_matcher():
     matcher = has_feature("name", lambda user: user.username, "bob")
-    assert_equal(
-        unmatched("name: was 'bobbity'"),
-        matcher.match(User("bobbity"))
-    )
+    assert unmatched("name: was 'bobbity'") == matcher.match(User("bobbity"))
 
 
-@istest
-def description_contains_description_of_property():
+def test_description_contains_description_of_property():
     matcher = has_feature("name", lambda user: user.username, equal_to("bob"))
-    assert_equal(
-        "name: 'bob'",
-        matcher.describe()
-    )
+    assert "name: 'bob'" == matcher.describe()
 

--- a/tests/includes_tests.py
+++ b/tests/includes_tests.py
@@ -1,90 +1,59 @@
-from nose.tools import istest, assert_equal
 
 from precisely import equal_to, includes
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_all_submatchers_match_one_item_with_no_items_leftover():
+def test_matches_when_all_submatchers_match_one_item_with_no_items_leftover():
     matcher = includes(equal_to("apple"), equal_to("banana"))
 
-    assert_equal(matched(), matcher.match(["apple", "banana"]))
-    assert_equal(matched(), matcher.match(["apple", "banana", "coconut"]))
+    assert matched() == matcher.match(["apple", "banana"])
+    assert matched() == matcher.match(["apple", "banana", "coconut"])
 
 
-@istest
-def mismatches_when_actual_is_not_iterable():
+def test_mismatches_when_actual_is_not_iterable():
     matcher = includes(equal_to("apple"))
 
-    assert_equal(
-        unmatched("was not iterable\nwas 0"),
-        matcher.match(0)
-    )
+    assert unmatched("was not iterable\nwas 0") == matcher.match(0)
 
 
-@istest
-def mismatches_when_item_is_missing():
+def test_mismatches_when_item_is_missing():
     matcher = includes(equal_to("apple"), equal_to("banana"), equal_to("coconut"))
 
-    assert_equal(
-        unmatched("was missing element:\n * 'banana'\nThese elements were in the iterable, but did not match the missing element:\n * 'coconut': was 'coconut'\n * 'apple': already matched"),
-        matcher.match(["coconut", "apple"])
-    )
+    assert unmatched("was missing element:\n * 'banana'\nThese elements were in the iterable, but did not match the missing element:\n * 'coconut': was 'coconut'\n * 'apple': already matched") == matcher.match(["coconut", "apple"])
 
 
-@istest
-def mismatches_when_duplicate_is_missing():
+def test_mismatches_when_duplicate_is_missing():
     matcher = includes(equal_to("apple"), equal_to("apple"))
 
-    assert_equal(
-        unmatched("was missing element:\n * 'apple'\nThese elements were in the iterable, but did not match the missing element:\n * 'apple': already matched"),
-        matcher.match(["apple"])
-    )
+    assert unmatched("was missing element:\n * 'apple'\nThese elements were in the iterable, but did not match the missing element:\n * 'apple': already matched") == matcher.match(["apple"])
 
 
-@istest
-def mismatches_when_item_is_expected_but_iterable_is_empty():
+def test_mismatches_when_item_is_expected_but_iterable_is_empty():
     matcher = includes(equal_to("apple"))
 
-    assert_equal(
-        unmatched("iterable was empty"),
-        matcher.match([])
-    )
+    assert unmatched("iterable was empty") == matcher.match([])
 
 
-@istest
-def when_no_elements_are_expected_then_empty_iterable_matches():
+def test_when_no_elements_are_expected_then_empty_iterable_matches():
     matcher = includes()
 
-    assert_equal(
-        matched(),
-        matcher.match([])
-    )
+    assert matched() == matcher.match([])
 
 
-@istest
-def matches_when_there_are_extra_items():
+def test_matches_when_there_are_extra_items():
     matcher = includes(equal_to("apple"))
 
-    assert_equal(matched(), matcher.match(["coconut", "apple"]))
+    assert matched() == matcher.match(["coconut", "apple"])
 
 
-@istest
-def description_contains_descriptions_of_submatchers():
+def test_description_contains_descriptions_of_submatchers():
     matcher = includes(equal_to("apple"), equal_to("banana"))
 
-    assert_equal(
-        "iterable including elements:\n * 'apple'\n * 'banana'",
-        matcher.describe()
-    )
+    assert "iterable including elements:\n * 'apple'\n * 'banana'" == matcher.describe()
 
 
-@istest
-def elements_are_coerced_to_matchers():
+def test_elements_are_coerced_to_matchers():
     matcher = includes("apple", "banana")
 
-    assert_equal(
-        "iterable including elements:\n * 'apple'\n * 'banana'",
-        matcher.describe()
-    )
+    assert "iterable including elements:\n * 'apple'\n * 'banana'" == matcher.describe()
 

--- a/tests/is_instance_tests.py
+++ b/tests/is_instance_tests.py
@@ -1,19 +1,14 @@
-from nose.tools import istest, assert_equal
-
 from precisely import is_instance
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_value_is_instance_of_class():
-    assert_equal(matched(), is_instance(int).match(1))
+def test_matches_when_value_is_instance_of_class():
+    assert matched() == is_instance(int).match(1)
 
 
-@istest
-def explanation_of_mismatch_contains_actual_type():
-    assert_equal(unmatched("had type float"), is_instance(int).match(1.0))
+def test_explanation_of_mismatch_contains_actual_type():
+    assert unmatched("had type float") == is_instance(int).match(1.0)
 
 
-@istest
-def description_includes_expected_type():
-    assert_equal("is instance of int", is_instance(int).describe())
+def test_description_includes_expected_type():
+    assert "is instance of int" == is_instance(int).describe()

--- a/tests/is_mapping_tests.py
+++ b/tests/is_mapping_tests.py
@@ -1,40 +1,33 @@
-from nose.tools import istest, assert_equal
 
 from precisely import equal_to, is_mapping
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_keys_and_values_match():
+def test_matches_when_keys_and_values_match():
     matcher = is_mapping({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal(matched(), matcher.match({"a": 1, "b": 2}))
+    assert matched() == matcher.match({"a": 1, "b": 2})
 
 
-@istest
-def values_are_coerced_to_matchers():
+def test_values_are_coerced_to_matchers():
     matcher = is_mapping({"a": 1, "b": 2})
-    assert_equal(matched(), matcher.match({"a": 1, "b": 2}))
+    assert matched() == matcher.match({"a": 1, "b": 2})
 
 
-@istest
-def does_not_match_when_value_does_not_match():
+def test_does_not_match_when_value_does_not_match():
     matcher = is_mapping({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal(unmatched("value for key 'b' mismatched:\n * was 3"), matcher.match({"a": 1, "b": 3}))
+    assert unmatched("value for key 'b' mismatched:\n * was 3") == matcher.match({"a": 1, "b": 3})
 
 
-@istest
-def does_not_match_when_keys_are_missing():
+def test_does_not_match_when_keys_are_missing():
     matcher = is_mapping({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal(unmatched("was missing key: 'b'"), matcher.match({"a": 1}))
+    assert unmatched("was missing key: 'b'") == matcher.match({"a": 1})
 
 
-@istest
-def does_not_match_when_there_are_extra_keys():
+def test_does_not_match_when_there_are_extra_keys():
     matcher = is_mapping({"a": equal_to(1)})
-    assert_equal(unmatched("had extra keys:\n * 'b'\n * 'c'"), matcher.match({"a": 1, "b": 1, "c": 1}))
+    assert unmatched("had extra keys:\n * 'b'\n * 'c'") == matcher.match({"a": 1, "b": 1, "c": 1})
 
 
-@istest
-def description_describes_keys_and_value_matchers():
+def test_description_describes_keys_and_value_matchers():
     matcher = is_mapping({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal("mapping with items:\n * 'a': 1\n * 'b': 2", matcher.describe())
+    assert "mapping with items:\n * 'a': 1\n * 'b': 2" == matcher.describe()

--- a/tests/is_sequence_tests.py
+++ b/tests/is_sequence_tests.py
@@ -1,102 +1,64 @@
-from nose.tools import istest, assert_equal
 
 from precisely import is_sequence, equal_to
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_all_submatchers_match_one_item_with_no_items_leftover():
+def test_matches_when_all_submatchers_match_one_item_with_no_items_leftover():
     matcher = is_sequence(equal_to("apple"), equal_to("banana"))
     
-    assert_equal(matched(), matcher.match(["apple", "banana"]))
+    assert matched() == matcher.match(["apple", "banana"])
 
 
-@istest
-def mismatches_when_actual_is_not_iterable():
+def test_mismatches_when_actual_is_not_iterable():
     matcher = is_sequence(equal_to("apple"))
 
-    assert_equal(
-        unmatched("was not iterable\nwas 0"),
-        matcher.match(0)
-    )
+    assert unmatched("was not iterable\nwas 0") == matcher.match(0)
 
 
-@istest
-def mismatches_when_items_are_in_wrong_order():
+def test_mismatches_when_items_are_in_wrong_order():
     matcher = is_sequence(equal_to("apple"), equal_to("banana"))
     
-    assert_equal(
-        unmatched("element at index 0 mismatched:\n * was 'banana'"),
-        matcher.match(["banana", "apple"])
-    )
+    assert unmatched("element at index 0 mismatched:\n * was 'banana'") == matcher.match(["banana", "apple"])
 
 
-@istest
-def mismatches_when_item_is_missing():
+def test_mismatches_when_item_is_missing():
     matcher = is_sequence(equal_to("apple"), equal_to("banana"), equal_to("coconut"))
     
-    assert_equal(
-        unmatched("element at index 2 was missing"),
-        matcher.match(["apple", "banana"])
-    )
+    assert unmatched("element at index 2 was missing") == matcher.match(["apple", "banana"])
 
 
-@istest
-def mismatches_when_item_is_expected_but_iterable_is_empty():
+def test_mismatches_when_item_is_expected_but_iterable_is_empty():
     matcher = is_sequence(equal_to("apple"))
 
-    assert_equal(
-        unmatched("iterable was empty"),
-        matcher.match([])
-    )
+    assert unmatched("iterable was empty") == matcher.match([])
 
 
-@istest
-def when_empty_iterable_is_expected_then_empty_iterable_matches():
+def test_when_empty_iterable_is_expected_then_empty_iterable_matches():
     matcher = is_sequence()
 
-    assert_equal(
-        matched(),
-        matcher.match([])
-    )
+    assert matched() == matcher.match([])
 
 
-@istest
-def mismatches_when_contains_extra_item():
+def test_mismatches_when_contains_extra_item():
     matcher = is_sequence(equal_to("apple"))
     
-    assert_equal(
-        unmatched("had extra elements:\n * 'coconut'"),
-        matcher.match(["apple", "coconut"])
-    )
+    assert unmatched("had extra elements:\n * 'coconut'") == matcher.match(["apple", "coconut"])
 
 
-@istest
-def when_there_are_zero_submatchers_then_description_is_of_empty_iterable():
+def test_when_there_are_zero_submatchers_then_description_is_of_empty_iterable():
     matcher = is_sequence()
 
-    assert_equal(
-        "empty iterable",
-        matcher.describe()
-    )
+    assert "empty iterable" == matcher.describe()
 
 
-@istest
-def description_contains_descriptions_of_submatchers():
+def test_description_contains_descriptions_of_submatchers():
     matcher = is_sequence(equal_to("apple"), equal_to("banana"))
     
-    assert_equal(
-        "iterable containing in order:\n 0: 'apple'\n 1: 'banana'",
-        matcher.describe()
-    )
+    assert "iterable containing in order:\n 0: 'apple'\n 1: 'banana'" == matcher.describe()
 
 
-@istest
-def elements_are_coerced_to_matchers():
+def test_elements_are_coerced_to_matchers():
     matcher = is_sequence("apple", "banana")
     
-    assert_equal(
-        "iterable containing in order:\n 0: 'apple'\n 1: 'banana'",
-        matcher.describe()
-    )
+    assert "iterable containing in order:\n 0: 'apple'\n 1: 'banana'" == matcher.describe()
 

--- a/tests/mapping_includes_tests.py
+++ b/tests/mapping_includes_tests.py
@@ -1,43 +1,33 @@
-from nose.tools import istest, assert_equal
 
 from precisely import equal_to, mapping_includes
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_keys_and_values_match():
+def test_matches_when_keys_and_values_match():
     matcher = mapping_includes({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal(matched(), matcher.match({"a": 1, "b": 2}))
+    assert matched() == matcher.match({"a": 1, "b": 2})
 
 
-@istest
-def values_are_coerced_to_matchers():
+def test_values_are_coerced_to_matchers():
     matcher = mapping_includes({"a": 1, "b": 2})
-    assert_equal(matched(), matcher.match({"a": 1, "b": 2}))
+    assert matched() == matcher.match({"a": 1, "b": 2})
 
 
-@istest
-def does_not_match_when_value_does_not_match():
+def test_does_not_match_when_value_does_not_match():
     matcher = mapping_includes({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal(
-        unmatched("value for key 'b' mismatched:\n * was 3"),
-        matcher.match({"a": 1, "b": 3, "c": 4}),
-    )
+    assert unmatched("value for key 'b' mismatched:\n * was 3") == matcher.match({"a": 1, "b": 3, "c": 4})
 
 
-@istest
-def does_not_match_when_keys_are_missing():
+def test_does_not_match_when_keys_are_missing():
     matcher = mapping_includes({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal(unmatched("was missing key: 'b'"), matcher.match({"a": 1}))
+    assert unmatched("was missing key: 'b'") == matcher.match({"a": 1})
 
 
-@istest
-def matches_when_there_are_extra_keys():
+def test_matches_when_there_are_extra_keys():
     matcher = mapping_includes({"a": equal_to(1)})
-    assert_equal(matched(), matcher.match({"a": 1, "b": 1, "c": 1}))
+    assert matched() == matcher.match({"a": 1, "b": 1, "c": 1})
 
 
-@istest
-def description_describes_keys_and_value_matchers():
+def test_description_describes_keys_and_value_matchers():
     matcher = mapping_includes({"a": equal_to(1), "b": equal_to(2)})
-    assert_equal("mapping including items:\n * 'a': 1\n * 'b': 2", matcher.describe())
+    assert "mapping including items:\n * 'a': 1\n * 'b': 2" == matcher.describe()

--- a/tests/not_tests.py
+++ b/tests/not_tests.py
@@ -1,19 +1,14 @@
-from nose.tools import istest, assert_equal
-
 from precisely import equal_to, not_
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_negated_matcher_does_not_match():
-    assert_equal(matched(), not_(equal_to(1)).match(2))
+def test_matches_when_negated_matcher_does_not_match():
+    assert matched() == not_(equal_to(1)).match(2)
 
 
-@istest
-def does_not_match_when_negated_matcher_matches():
-    assert_equal(unmatched("matched: 1"), not_(equal_to(1)).match(1))
+def test_does_not_match_when_negated_matcher_matches():
+    assert unmatched("matched: 1") == not_(equal_to(1)).match(1)
 
 
-@istest
-def description_includes_description_of_negated_matcher():
-    assert_equal("not: 'hello'", not_(equal_to("hello")).describe())
+def test_description_includes_description_of_negated_matcher():
+    assert "not: 'hello'" == not_(equal_to("hello")).describe()

--- a/tests/numeric_comparison_tests.py
+++ b/tests/numeric_comparison_tests.py
@@ -1,60 +1,49 @@
-from nose.tools import istest, assert_equal
-
 from precisely import greater_than, greater_than_or_equal_to, less_than, less_than_or_equal_to
 from precisely.results import matched, unmatched
 
 
-@istest
-def greater_than_matches_when_actual_is_greater_than_value():
+def test_greater_than_matches_when_actual_is_greater_than_value():
     matcher = greater_than(42)
-    assert_equal(matched(), matcher.match(43))
-    assert_equal(unmatched("was 42"), matcher.match(42))
-    assert_equal(unmatched("was 41"), matcher.match(41))
+    assert matched() == matcher.match(43)
+    assert unmatched("was 42") == matcher.match(42)
+    assert unmatched("was 41") == matcher.match(41)
 
 
-@istest
-def greater_than_description_describes_value():
+def test_greater_than_description_describes_value():
     matcher = greater_than(42)
-    assert_equal("greater than 42", matcher.describe())
+    assert matcher.describe() == "greater than 42"
 
-
-@istest
-def greater_than_or_equal_to_matches_when_actual_is_greater_than_or_equal_to_value():
+def test_greater_than_or_equal_to_matches_when_actual_is_greater_than_or_equal_to_value():
     matcher = greater_than_or_equal_to(42)
-    assert_equal(matched(), matcher.match(43))
-    assert_equal(matched(), matcher.match(42))
-    assert_equal(unmatched("was 41"), matcher.match(41))
+    assert matched() == matcher.match(43)
+    assert matched() == matcher.match(42)
+    assert unmatched("was 41") == matcher.match(41)
 
 
-@istest
-def greater_than_or_equal_to_description_describes_value():
+def test_greater_than_or_equal_to_description_describes_value():
     matcher = greater_than_or_equal_to(42)
-    assert_equal("greater than or equal to 42", matcher.describe())
+    assert matcher.describe() == "greater than or equal to 42"
 
 
-@istest
-def less_than_matches_when_actual_is_less_than_value():
+def test_less_than_matches_when_actual_is_less_than_value():
     matcher = less_than(42)
-    assert_equal(matched(), matcher.match(41))
-    assert_equal(unmatched("was 42"), matcher.match(42))
-    assert_equal(unmatched("was 43"), matcher.match(43))
+    assert matched() == matcher.match(41)
+    assert unmatched("was 42") == matcher.match(42)
+    assert unmatched("was 43") == matcher.match(43)
 
 
-@istest
-def less_than_description_describes_value():
+def test_less_than_description_describes_value():
     matcher = less_than(42)
-    assert_equal("less than 42", matcher.describe())
+    assert matcher.describe() == "less than 42"
 
 
-@istest
-def less_than_or_equal_to_matches_when_actual_is_less_than_or_equal_to_value():
+def test_less_than_or_equal_to_matches_when_actual_is_less_than_or_equal_to_value():
     matcher = less_than_or_equal_to(42)
-    assert_equal(matched(), matcher.match(41))
-    assert_equal(matched(), matcher.match(42))
-    assert_equal(unmatched("was 43"), matcher.match(43))
+    assert matched() == matcher.match(41)
+    assert matched() == matcher.match(42)
+    assert unmatched("was 43") == matcher.match(43)
 
 
-@istest
-def less_than_or_equal_to_description_describes_value():
+def test_less_than_or_equal_to_description_describes_value():
     matcher = less_than_or_equal_to(42)
-    assert_equal("less than or equal to 42", matcher.describe())
+    assert matcher.describe() == "less than or equal to 42"

--- a/tests/raises_tests.py
+++ b/tests/raises_tests.py
@@ -1,26 +1,22 @@
-from nose.tools import istest, assert_equal
 
 from precisely import is_instance, raises
 from precisely.results import matched, unmatched
 
 
-@istest
-def matches_when_expected_exception_is_raised():
+def test_matches_when_expected_exception_is_raised():
     def raise_key_error():
         raise KeyError()
 
     matcher = raises(is_instance(KeyError))
-    assert_equal(matched(), matcher.match(raise_key_error))
+    assert matched() == matcher.match(raise_key_error)
 
 
-@istest
-def mismatches_when_no_exception_is_raised():
+def test_mismatches_when_no_exception_is_raised():
     matcher = raises(is_instance(KeyError))
-    assert_equal(unmatched("did not raise exception"), matcher.match(lambda: None))
+    assert unmatched("did not raise exception") == matcher.match(lambda: None)
 
 
-@istest
-def mismatches_when_unexpected_exception_is_raised():
+def test_mismatches_when_unexpected_exception_is_raised():
     def raise_key_error():
         raise KeyError()
 
@@ -32,16 +28,14 @@ def mismatches_when_unexpected_exception_is_raised():
     )
 
 
-@istest
-def mismatches_when_value_is_not_callable():
+def test_mismatches_when_value_is_not_callable():
     matcher = raises(is_instance(ValueError))
-    assert_equal(unmatched("was not callable"), matcher.match(42))
+    assert unmatched("was not callable") == matcher.match(42)
 
 
-@istest
-def description_includes_description_of_exception():
+def test_description_includes_description_of_exception():
     matcher = raises(is_instance(ValueError))
-    assert_equal("a callable raising: is instance of ValueError", matcher.describe())
+    assert matcher.describe() == "a callable raising: is instance of ValueError"
 
 
 def _normalise_newlines(string):

--- a/tests/results_tests.py
+++ b/tests/results_tests.py
@@ -1,14 +1,8 @@
-from nose.tools import istest, assert_equal
-
-from precisely.results import indented_list  
+from precisely.results import indented_list
 
 
-@istest
-def indented_list_indents_children():
-    assert_equal(
-        "\n * apple\n    * banana\n    * coconut\n * durian",
-        indented_list([
-            "apple" + indented_list(["banana", "coconut"]),
-            "durian",
-        ])
-    )
+def test_indented_list_indents_children():
+    assert indented_list([
+        "apple" + indented_list(["banana", "coconut"]),
+        "durian",
+    ]) == "\n * apple\n    * banana\n    * coconut\n * durian"

--- a/tests/starts_with_tests.py
+++ b/tests/starts_with_tests.py
@@ -1,20 +1,16 @@
-from nose.tools import istest, assert_equal
-
 from precisely import starts_with
 from precisely.results import matched, unmatched
 
 
-@istest
-def starts_with_matches_when_actual_string_starts_with_value_passed_to_matcher():
+def test_starts_with_matches_when_actual_string_starts_with_value_passed_to_matcher():
     matcher = starts_with("ab")
-    assert_equal(matched(), matcher.match("ab"))
-    assert_equal(matched(), matcher.match("abc"))
-    assert_equal(matched(), matcher.match("abcd"))
-    assert_equal(unmatched("was 'a'"), matcher.match("a"))
-    assert_equal(unmatched("was 'cab'"), matcher.match("cab"))
+    assert matched() == matcher.match("ab")
+    assert matched() == matcher.match("abc")
+    assert matched() == matcher.match("abcd")
+    assert unmatched("was 'a'") == matcher.match("a")
+    assert unmatched("was 'cab'") == matcher.match("cab")
 
 
-@istest
-def starts_with_description_describes_value():
+def test_starts_with_description_describes_value():
     matcher = starts_with("ab")
-    assert_equal("starts with 'ab'", matcher.describe())
+    assert "starts with 'ab'" == matcher.describe()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py35,py36,py37,py38,py39,pypy,docs
 changedir = {envtmpdir}
 deps=-r{toxinidir}/test-requirements.txt
 commands=
-    nosetests {toxinidir}/tests
+    pytest {toxinidir}/tests
     pyflakes {toxinidir}/precisely {toxinidir}/tests
 [testenv:docs]
 deps=
@@ -12,3 +12,6 @@ deps=
     pygments==2.1.3
 commands=
     rst-lint {toxinidir}/README.rst
+
+[pytest]
+python_files = *_tests.py


### PR DESCRIPTION
The latest version of [`nose`](https://pypi.org/project/nose/#history) does not support python > 3.10. Rather than attempting to fix, patch or fork the nose project to add support I suggest `precisely` switches to [`pytest`](https://docs.pytest.org/en/stable/) as a unit test framework (pytest is currently well supported and is closer to an industry standard etc.). 

This PR implements that change. 

Merging this PR would enable further changes such as 
* adding support for more recent python versions
* updating the linter away from pyflakes
* adding new matchers
