### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,0 +1,47 @@
+name: Legacy Tests (for elderly pythons)
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  legacy:
+    name: py${{ matrix.py }} (container)
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        py: ["2.7", "3.5", "3.6", "3.7"]
+    container:
+      # Use Docker Hub python images to get the exact interpreter
+      image: python:${{ matrix.py }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Toolchain pins per interpreter ---
+      - name: Bootstrap tools (py27)
+        if: matrix.py == '2.7'
+        run: |
+          python -V
+          python -m pip install -U 'pip<21' 'setuptools<45' 'wheel<0.35' 'tox<4'
+      - name: Bootstrap tools (py35)
+        if: matrix.py == '3.5'
+        run: |
+          python -V
+          python -m pip install -U 'pip<22' 'setuptools<51' 'wheel<0.37' 'tox<4'
+      - name: Bootstrap tools (py36)
+        if: matrix.py == '3.6'
+        run: |
+          python -V
+          python -m pip install -U 'pip<23' 'setuptools<60' 'wheel<0.38' 'tox<4'
+      - name: Bootstrap tools (py37)
+        if: matrix.py == '3.7'
+        run: |
+          python -V
+          python -m pip install -U 'pip<24' 'setuptools<70' 'wheel<0.41' 'tox<4'
+
+      # --- Install deps & run tests ---
+      - name: Test via tox (preferred)
+        run: |
+          tox -vv -e py$(echo ${{ matrix.py }} | tr -d .)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,42 +3,46 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy2.7", "pypy3.9"]
+        python-version: ["3.8", "3.9", "pypy3.9"]
 
     steps:
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    - name: Use Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            setup.py
+            tox.ini
 
-    - run: pip install tox
+      - run: pip install tox
 
-    - run: tox -e py
+      - run: tox -e py
 
   docs:
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        python-version: ["3.9"]
+    runs-on: ubuntu-latest
 
     steps:
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    - name: Use Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: |
+            setup.py
+            tox.ini
 
-    - run: pip install tox
+      - run: pip install tox
 
-    - run: tox -e docs
+      - run: tox -e docs


### PR DESCRIPTION
The github action is outdated and failing.
Older pythons are no longer supported. 

This PR updates the action so the tests can start building. It also adds a 'legacy' action to jury-rig builds for older less-supported pythons. 

Once the CI is functional I believe other decisions on supporting or deprecating can be made, but these are difficult to reason about without a functional CI 

CF #23